### PR TITLE
Update CleanupFailureTest to perform deterministic cleanup bootstrap/decommission

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3850,9 +3850,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
         InetAddressAndPort localAddress = FBUtilities.getBroadcastAddressAndPort();
-        Integer pendingRangesCount = tokenMetadata.getPendingRanges(keyspaceName, localAddress).size();
-
-        if (pendingRangesCount > 0)
+        if (tokenMetadata.getPendingRanges(keyspaceName, localAddress).size() > 0)
         {
             throw new RuntimeException("Node is involved in cluster membership changes. Not safe to run cleanup.");
         }

--- a/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
@@ -73,6 +73,18 @@ public class GossipHelper
         };
     }
 
+    public static InstanceAction statusToDecommission(IInvokableInstance newNode)
+    {
+        return (instance) ->
+        {
+            changeGossipState(instance,
+                              newNode,
+                              Arrays.asList(tokens(newNode),
+                                            statusLeaving(newNode),
+                                            statusWithPortLeaving(newNode)));
+        };
+    }
+
     public static InstanceAction statusToNormal(IInvokableInstance peer)
     {
         return (target) ->


### PR DESCRIPTION
This PR reworks `CleanupFailureTest` to use a different approach: instead of requiring cleanup to be run in the short window between streaming and range movement completion, these new tests inject boostrap/leaving state to simulate an ongoing bootstrap/decommission and run cleanup during that state, expecting written rows to not be removed. This allow us to check that the cleanup fails with the expected error message.

This also has a cosmetic nit of removing the `pendingRangesCount` variable from `forceKeyspaceCleanup`.